### PR TITLE
remove autoload for non-existent vendor folder

### DIFF
--- a/src/Kazoo/SDK.php
+++ b/src/Kazoo/SDK.php
@@ -2,8 +2,6 @@
 
 namespace Kazoo;
 
-require_once dirname(__FILE__) . "/../../vendor/autoload.php";
-
 use \BadFunctionCallException;
 
 use Kazoo\Common\Log;


### PR DESCRIPTION
./vendor/autoload.php does not exist. vendor/autoload.php should be in project root folder and doesn't need to be included from SDK.php
